### PR TITLE
set binary name on windows to "mc.exe"

### DIFF
--- a/R/mc.R
+++ b/R/mc.R
@@ -19,7 +19,10 @@
 #' The R package provides wrappers only for the most common use cases,
 #' which provide a more natural R syntax and native documentation.
 mc <- function(command, ..., path = minio_path(), verbose = interactive()) {
-  
+  binaryname <- "mc"
+  if (.Platform$OS.type == "windows") {
+    binaryname <- "mc.exe"
+  }
   binary <- fs::path(path, "mc")
   if(!file.exists(binary) && interactive()) {
     proceed <- utils::askYesNo(


### PR DESCRIPTION
this prevents repeated prompt messages on Windows to find the installed mc (I haven't tested further)